### PR TITLE
FilamentUppyServiceProvider: Register JS in...

### DIFF
--- a/src/FilamentUppyPlugin.php
+++ b/src/FilamentUppyPlugin.php
@@ -20,10 +20,6 @@ class FilamentUppyPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        $panel
-            ->assets([
-                Js::make('sts-filament-uppy', __DIR__ . '/../resources/dist/filament-uppy-component.js'),
-            ]);
     }
 
     public function boot(Panel $panel): void

--- a/src/FilamentUppyServiceProvider.php
+++ b/src/FilamentUppyServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace STS\FilamentUppy;
 
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -14,5 +16,12 @@ class FilamentUppyServiceProvider extends PackageServiceProvider
         $package
             ->name(static::$name)
             ->hasViews();
+    }
+
+    public function packageBooted(): void
+    {
+        FilamentAsset::register([
+            Js::make('sts-filament-uppy', __DIR__ . '/../resources/dist/filament-uppy-component.js'),
+        ]);
     }
 }


### PR DESCRIPTION
...the package service provider such that it can be used anywhere where the Filament assets are loaded via `@filamentScripts`. Since these assets are related to components which can be used both within and without Filament panels, it would be nice if all such assets are registered with Filament globally (rather than just per-panel).

-----

Example plugin where assets are registered in this way:

* https://filamentphp.com/plugins/leandrocfe-apex-charts
* https://github.com/leandrocfe/filament-apex-charts/blob/master/src/FilamentApexChartsServiceProvider.php#L46

Relevant documentation:

* https://filamentphp.com/docs/3.x/support/assets#registering-javascript-files