### PR TITLE
Ensure State & Event Consistency

### DIFF
--- a/resources/dist/filament-uppy-component.js
+++ b/resources/dist/filament-uppy-component.js
@@ -887,7 +887,7 @@
     return "__private_" + id2++ + "_" + e2;
   }
   var packageJson = {
-    "version": "4.0.0"
+    "version": "4.1.0"
   };
   var _callbacks = /* @__PURE__ */ _classPrivateFieldLooseKey2("callbacks");
   var _publish = /* @__PURE__ */ _classPrivateFieldLooseKey2("publish");
@@ -1353,7 +1353,7 @@
     return "__private_" + id3++ + "_" + e2;
   }
   var packageJson2 = {
-    "version": "4.0.1"
+    "version": "4.1.2"
   };
   var defaultUploadState = {
     totalProgress: 0,
@@ -2194,7 +2194,7 @@
       const existsPluginAlready = this.getPlugin(pluginId);
       if (existsPluginAlready) {
         const msg = `Already found a plugin named '${existsPluginAlready.id}'. Tried to use: '${pluginId}'.
-Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#id.`;
+Uppy plugins must have unique \`id\` options.`;
         throw new Error(msg);
       }
       if (Plugin.VERSION) {
@@ -2956,12 +2956,12 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
   }
   function S(n2, l2, u2, t2, i2, o2, r2, f2, e2, c2, s2) {
     var a2, v2, y2, d2, w2, _2 = t2 && t2.__k || p, g2 = l2.length;
-    for (u2.__d = e2, $(u2, l2, _2), e2 = u2.__d, a2 = 0; a2 < g2; a2++) null != (y2 = u2.__k[a2]) && "boolean" != typeof y2 && "function" != typeof y2 && (v2 = -1 === y2.__i ? h : _2[y2.__i] || h, y2.__i = a2, O(n2, y2, v2, i2, o2, r2, f2, e2, c2, s2), d2 = y2.__e, y2.ref && v2.ref != y2.ref && (v2.ref && N(v2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 65536 & y2.__u || v2.__k === y2.__k ? (e2 && "string" == typeof y2.type && !n2.contains(e2) && (e2 = x(v2)), e2 = I(y2, e2, n2)) : "function" == typeof y2.type && void 0 !== y2.__d ? e2 = y2.__d : d2 && (e2 = d2.nextSibling), y2.__d = void 0, y2.__u &= -196609);
+    for (u2.__d = e2, $(u2, l2, _2), e2 = u2.__d, a2 = 0; a2 < g2; a2++) null != (y2 = u2.__k[a2]) && "boolean" != typeof y2 && "function" != typeof y2 && (v2 = -1 === y2.__i ? h : _2[y2.__i] || h, y2.__i = a2, O(n2, y2, v2, i2, o2, r2, f2, e2, c2, s2), d2 = y2.__e, y2.ref && v2.ref != y2.ref && (v2.ref && N(v2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 65536 & y2.__u || v2.__k === y2.__k ? e2 = I(y2, e2, n2) : "function" == typeof y2.type && void 0 !== y2.__d ? e2 = y2.__d : d2 && (e2 = d2.nextSibling), y2.__d = void 0, y2.__u &= -196609);
     u2.__d = e2, u2.__e = w2;
   }
   function $(n2, l2, u2) {
     var t2, i2, o2, r2, f2, e2 = l2.length, c2 = u2.length, s2 = c2, a2 = 0;
-    for (n2.__k = [], t2 = 0; t2 < e2; t2++) r2 = t2 + a2, null != (i2 = n2.__k[t2] = null == (i2 = l2[t2]) || "boolean" == typeof i2 || "function" == typeof i2 ? null : "string" == typeof i2 || "number" == typeof i2 || "bigint" == typeof i2 || i2.constructor == String ? g(null, i2, null, null, null) : y(i2) ? g(k, { children: i2 }, null, null, null) : void 0 === i2.constructor && i2.__b > 0 ? g(i2.type, i2.props, i2.key, i2.ref ? i2.ref : null, i2.__v) : i2) ? (i2.__ = n2, i2.__b = n2.__b + 1, f2 = L(i2, u2, r2, s2), i2.__i = f2, o2 = null, -1 !== f2 && (s2--, (o2 = u2[f2]) && (o2.__u |= 131072)), null == o2 || null === o2.__v ? (-1 == f2 && a2--, "function" != typeof i2.type && (i2.__u |= 65536)) : f2 !== r2 && (f2 == r2 - 1 ? a2 = f2 - r2 : f2 == r2 + 1 ? a2++ : f2 > r2 ? s2 > e2 - r2 ? a2 += f2 - r2 : a2-- : f2 < r2 && a2++, f2 !== t2 + a2 && (i2.__u |= 65536))) : (o2 = u2[r2]) && null == o2.key && o2.__e && 0 == (131072 & o2.__u) && (o2.__e == n2.__d && (n2.__d = x(o2)), V(o2, o2, false), u2[r2] = null, s2--);
+    for (n2.__k = [], t2 = 0; t2 < e2; t2++) r2 = t2 + a2, null != (i2 = n2.__k[t2] = null == (i2 = l2[t2]) || "boolean" == typeof i2 || "function" == typeof i2 ? null : "string" == typeof i2 || "number" == typeof i2 || "bigint" == typeof i2 || i2.constructor == String ? g(null, i2, null, null, null) : y(i2) ? g(k, { children: i2 }, null, null, null) : void 0 === i2.constructor && i2.__b > 0 ? g(i2.type, i2.props, i2.key, i2.ref ? i2.ref : null, i2.__v) : i2) ? (i2.__ = n2, i2.__b = n2.__b + 1, f2 = L(i2, u2, r2, s2), i2.__i = f2, o2 = null, -1 !== f2 && (s2--, (o2 = u2[f2]) && (o2.__u |= 131072)), null == o2 || null === o2.__v ? (-1 == f2 && a2--, "function" != typeof i2.type && (i2.__u |= 65536)) : f2 !== r2 && (f2 == r2 - 1 ? a2-- : f2 == r2 + 1 ? a2++ : f2 > r2 ? s2 > e2 - r2 ? a2 += f2 - r2 : a2-- : f2 < r2 && (f2 == r2 - a2 ? a2 -= f2 - r2 : a2++), f2 !== t2 + a2 && (i2.__u |= 65536))) : (o2 = u2[r2]) && null == o2.key && o2.__e && 0 == (131072 & o2.__u) && (o2.__e == n2.__d && (n2.__d = x(o2)), V(o2, o2, false), u2[r2] = null, s2--);
     if (s2) for (t2 = 0; t2 < c2; t2++) null != (o2 = u2[t2]) && 0 == (131072 & o2.__u) && (o2.__e == n2.__d && (n2.__d = x(o2)), V(o2, o2));
   }
   function I(n2, l2, u2) {
@@ -2970,7 +2970,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
       for (t2 = n2.__k, i2 = 0; t2 && i2 < t2.length; i2++) t2[i2] && (t2[i2].__ = n2, l2 = I(t2[i2], l2, u2));
       return l2;
     }
-    n2.__e != l2 && (u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
+    n2.__e != l2 && (l2 && n2.type && !u2.contains(l2) && (l2 = x(n2)), u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
     do {
       l2 = l2 && l2.nextSibling;
     } while (null != l2 && 8 === l2.nodeType);
@@ -3048,7 +3048,11 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
       } while (h2.__d && ++I2 < 25);
       h2.state = h2.__s, null != h2.getChildContext && (i2 = d(d({}, i2), h2.getChildContext())), x2 && !p2 && null != h2.getSnapshotBeforeUpdate && (_2 = h2.getSnapshotBeforeUpdate(v2, w2)), S(n2, y(L2 = null != a2 && a2.type === k && null == a2.key ? a2.props.children : a2) ? L2 : [L2], u2, t2, i2, o2, r2, f2, e2, c2, s2), h2.base = u2.__e, u2.__u &= -161, h2.__h.length && f2.push(h2), g2 && (h2.__E = h2.__ = null);
     } catch (n3) {
-      u2.__v = null, c2 || null != r2 ? (u2.__e = e2, u2.__u |= c2 ? 160 : 32, r2[r2.indexOf(e2)] = null) : (u2.__e = t2.__e, u2.__k = t2.__k), l.__e(n3, u2, t2);
+      if (u2.__v = null, c2 || null != r2) {
+        for (u2.__u |= c2 ? 160 : 32; e2 && 8 === e2.nodeType && e2.nextSibling; ) e2 = e2.nextSibling;
+        r2[r2.indexOf(e2)] = null, u2.__e = e2;
+      } else u2.__e = t2.__e, u2.__k = t2.__k;
+      l.__e(n3, u2, t2);
     }
     else null == r2 && u2.__v === t2.__v ? (u2.__k = t2.__k, u2.__e = t2.__e) : u2.__e = z(t2.__e, u2, t2, i2, o2, r2, f2, c2, s2);
     (a2 = l.diffed) && a2(u2);
@@ -3096,7 +3100,10 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
   }
   function N(n2, u2, t2) {
     try {
-      "function" == typeof n2 ? n2(u2) : n2.current = u2;
+      if ("function" == typeof n2) {
+        var i2 = "function" == typeof n2.__u;
+        i2 && n2.__u(), i2 && null == u2 || (n2.__u = n2(u2));
+      } else n2.current = u2;
     } catch (n3) {
       l.__e(n3, t2);
     }
@@ -3582,7 +3589,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
     return "__private_" + id5++ + "_" + e2;
   }
   var packageJson3 = {
-    "version": "4.0.0"
+    "version": "4.0.1"
   };
   function stripSlash(url) {
     return url.replace(/\/$/, "");
@@ -5214,7 +5221,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
     return "__private_" + id10++ + "_" + e2;
   }
   var packageJson4 = {
-    "version": "4.0.1"
+    "version": "4.0.3"
   };
   function assertServerError(res) {
     if (res != null && res.error) {
@@ -5569,6 +5576,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
       }).then(assertServerError);
     }
     getUploadParameters(file, options) {
+      _classPrivateFieldLooseBase10(this, _assertHost)[_assertHost]("getUploadParameters");
       const {
         meta
       } = file;
@@ -5866,7 +5874,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
 
   // node_modules/@uppy/file-input/lib/FileInput.js
   var packageJson5 = {
-    "version": "4.0.0"
+    "version": "4.0.1"
   };
   var defaultOptions4 = {
     pretty: true,
@@ -5911,6 +5919,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
       this.input.click();
     }
     render() {
+      var _restrictions$allowed;
       const hiddenInputStyle = {
         width: "0.1px",
         height: "0.1px",
@@ -5922,7 +5931,6 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
       const {
         restrictions
       } = this.uppy.opts;
-      const accept = restrictions.allowedFileTypes ? restrictions.allowedFileTypes.join(",") : void 0;
       return _("div", {
         className: "uppy-FileInput-container"
       }, _("input", {
@@ -5932,7 +5940,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
         name: this.opts.inputName,
         onChange: this.handleInputChange,
         multiple: restrictions.maxNumberOfFiles !== 1,
-        accept,
+        accept: (_restrictions$allowed = restrictions.allowedFileTypes) == null ? void 0 : _restrictions$allowed.join(", "),
         ref: (input) => {
           this.input = input;
         }
@@ -5969,6 +5977,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
   }) {
     return {
       state,
+      internalState: [],
       busy: false,
       dragDepth: 0,
       filesInProgress: {},
@@ -5981,6 +5990,7 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
         if (!Array.isArray(this.state)) {
           this.state = [];
         }
+        this.internalState = this.state;
         window.addEventListener("beforeunload", (e2) => {
           if (!this.busy) return;
           e2.preventDefault();
@@ -6000,13 +6010,14 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
         }).on("upload-progress", (file, progress) => this.filesInProgress[file.id].progress = (progress.bytesUploaded / progress.bytesTotal * 100).toFixed(0)).on("upload-success", (file, response) => {
           this.removeFileInProgress(file.id);
           this.toggleFormProcessingState();
-          if (!this.state.find((stateFile) => stateFile.id === file.id)) {
-            this.state.push({
+          if (!this.internalState.find((stateFile) => stateFile.id === file.id)) {
+            this.internalState.push({
               id: file.id,
               name: file.name,
               size: file.size,
               url: response.uploadURL
             });
+            this.state = this.internalState;
           }
           if (!!successEndpoint) {
             const key = response.uploadURL.split("/").pop();
@@ -6061,9 +6072,10 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
         this.recalculateBusy();
       },
       removeCompletedFile(index) {
-        const file = this.state[index];
+        const file = this.internalState[index];
         if (!!file) {
-          this.state.splice(index, 1);
+          this.internalState.splice(index, 1);
+          this.state = this.internalState;
           if (!!deleteEndpoint) {
             const key = file.url.split("/").pop();
             const uuid = key.split(".")[0];
@@ -6097,13 +6109,15 @@ Uppy plugins must have unique \`id\` options. See https://uppy.io/docs/plugins/#
         for (const file of this.uppy.getFiles()) {
           if (!file.error && file.progress.bytesUploaded < file.progress.bytesTotal) {
             uploadsInProgress = true;
+            break;
           }
         }
         if (uploadsInProgress) {
           this.dispatchFormEvent("form-processing-started", {
-            message: this.uploadingMessage
+            message: uploadingMessage
           });
         } else {
+          this.state = this.internalState;
           this.dispatchFormEvent("form-processing-finished");
         }
       },

--- a/resources/js/filament-uppy-component.js
+++ b/resources/js/filament-uppy-component.js
@@ -178,7 +178,7 @@ window.fileUploaderComponent = function fileUploaderComponent({
 
             if (uploadsInProgress) {
                 this.dispatchFormEvent('form-processing-started', {
-                    message: this.uploadingMessage,
+                    message: uploadingMessage,
                 });
             } else {
                 this.dispatchFormEvent('form-processing-finished');

--- a/resources/js/filament-uppy-component.js
+++ b/resources/js/filament-uppy-component.js
@@ -127,34 +127,37 @@ window.fileUploaderComponent = function fileUploaderComponent({
         },
 
         removeFileInProgress(id) {
-            this.uppy.removeFile(id);
-            delete this.filesInProgress[id];
-            this.recalculateBusy();
+            this.withFormProcessingAndBusy(() => {
+                this.uppy.removeFile(id);
+                delete this.filesInProgress[id];
+            });
         },
 
         removeCompletedFile(index) {
-            const file = this.internalState[index];
+            this.withFormProcessingAndBusy(() => {
+                const file = this.internalState[index];
 
-            if (!!file) {
-                this.internalState.splice(index, 1);
-                this.state = this.internalState;
+                if (!!file) {
+                    this.internalState.splice(index, 1);
+                    this.state = this.internalState;
 
-                if (!!deleteEndpoint) {
-                    const key = file.url.split('/').pop();
-                    const uuid = key.split('.')[0];
-                    const name = file.name;
-                    const url = file.url;
+                    if (!!deleteEndpoint) {
+                        const key = file.url.split('/').pop();
+                        const uuid = key.split('.')[0];
+                        const name = file.name;
+                        const url = file.url;
 
-                    fetch(deleteEndpoint, {
-                        method: 'DELETE',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                        },
-                        body: JSON.stringify({ name, url, uuid }),
-                    });
+                        fetch(deleteEndpoint, {
+                            method: 'DELETE',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                            },
+                            body: JSON.stringify({ name, url, uuid }),
+                        });
+                    }
                 }
-            }
+            });
         },
 
         recalculateBusy() {
@@ -200,6 +203,18 @@ window.fileUploaderComponent = function fileUploaderComponent({
                     detail,
                 }),
             )
+        },
+
+        withFormProcessingAndBusy(cb) {
+            this.dispatchFormEvent('form-processing-started', {
+                message: uploadingMessage,
+            });
+            this.busy = true;
+
+            cb();
+
+            this.recalculateBusy();
+            this.toggleFormProcessingState();
         },
     }
 }

--- a/resources/js/filament-uppy-component.js
+++ b/resources/js/filament-uppy-component.js
@@ -17,6 +17,7 @@ window.fileUploaderComponent = function fileUploaderComponent({
 }) {
     return {
         state,
+        internalState: [],
 
         busy: false,
 
@@ -34,6 +35,8 @@ window.fileUploaderComponent = function fileUploaderComponent({
             if (!Array.isArray(this.state)) {
                 this.state = [];
             }
+
+            this.internalState = this.state;
 
             window.addEventListener('beforeunload', (e) => {
                 if (!this.busy) return;
@@ -61,13 +64,14 @@ window.fileUploaderComponent = function fileUploaderComponent({
                     this.toggleFormProcessingState();
 
                     // If state array does not contain a file with the same id, add it.
-                    if (!this.state.find((stateFile) => stateFile.id === file.id)) {
-                        this.state.push({
+                    if (!this.internalState.find((stateFile) => stateFile.id === file.id)) {
+                        this.internalState.push({
                             id: file.id,
                             name: file.name,
                             size: file.size,
                             url: response.uploadURL,
                         });
+                        this.state = this.internalState;
                     }
 
                     if (!!successEndpoint) {
@@ -129,10 +133,11 @@ window.fileUploaderComponent = function fileUploaderComponent({
         },
 
         removeCompletedFile(index) {
-            const file = this.state[index];
+            const file = this.internalState[index];
 
             if (!!file) {
-                this.state.splice(index, 1);
+                this.internalState.splice(index, 1);
+                this.state = this.internalState;
 
                 if (!!deleteEndpoint) {
                     const key = file.url.split('/').pop();
@@ -182,6 +187,7 @@ window.fileUploaderComponent = function fileUploaderComponent({
                     message: uploadingMessage,
                 });
             } else {
+                this.state = this.internalState;
                 this.dispatchFormEvent('form-processing-finished');
             }
         },

--- a/resources/js/filament-uppy-component.js
+++ b/resources/js/filament-uppy-component.js
@@ -173,6 +173,7 @@ window.fileUploaderComponent = function fileUploaderComponent({
                 // If there is a file that is not an error and is not fully uploaded, we consider the form to be processing.
                 if (!file.error && file.progress.bytesUploaded < file.progress.bytesTotal) {
                     uploadsInProgress = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
This PR fixes three bugs I discovered recently:

1. Livewire `update` calls which happen due to other form interactions while uploads are in progress were clobbering front-end state updates that occur during such calls. Now we never overwrite the current state of the uploads-in-progress. The front-end's internal state should always take precedence.
2. The event `uploadingMessage` was only being respected when the upload first started, but subsequent processing events would drop the message (leading to buttons relying on the message to drop their label completely while uploads were in progress). Now the message is retained through the entire uploading lifecycle.
3. When an upload in progress is cancelled it does not fire the `form-processing-finished` event even if it's the last active upload. This had the effect of leaving buttons which rely on this event in a busy state (thus the user could never submit the form). I've updated the code to ensure that any time an upload is being cancelled or removed we fire the appropriate events and (for consistency) update the `busy` status. Now things work as expected with respect to both canceling and removing uploads.

I've done extensive manual testing of these fixes (especially the first two) in the application I'm using this library within and things are working very well.