### PR TITLE
UppyUploader: Add support for drag-n-dropping...

### DIFF
--- a/resources/views/uppy-uploader.blade.php
+++ b/resources/views/uppy-uploader.blade.php
@@ -32,14 +32,7 @@
             x-on:dragenter.prevent.stop="dragDepth++"
             x-on:dragleave.prevent.stop="dragDepth--"
             x-on:dragover.prevent.stop=""
-            x-on:drop.prevent.stop="([...event.dataTransfer.files]).forEach((file) => {
-                uppy.addFile({
-                    name: file.name,
-                    type: file.type,
-                    data: file,
-                });
-                dragDepth = 0;
-            })"
+            x-on:drop.prevent.stop="handleDrop"
         >
             <table
                 x-show="internalState.filled()"


### PR DESCRIPTION
...a folder of files (rather than merely files themselves).

* `filament-uppy-component`: Implement `handleDrop()` method, making use of Uppy's `getDroppedFiles` helper routine to correctly process dropped files which in fact folders filled with files.
* `UppyUploader`: Utilize the new `handleDrop()` handler method of our component.