### PR TITLE
Add CI testing across PHP 8.3-8.5 and Filament 3-5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,18 @@ jobs:
             filament: '^5.0'
             laravel: '12.*'
             testbench: '10.*'
+          - php: '8.3'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
+          - php: '8.4'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
+          - php: '8.5'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
 
     name: PHP ${{ matrix.php }} - Filament ${{ matrix.filament }} - Laravel ${{ matrix.laravel }}
 
@@ -75,7 +87,9 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "filament/filament:${{ matrix.filament }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer require "pestphp/pest-plugin-laravel:^3.0" --no-interaction --no-update
+          if [[ "${{ matrix.laravel }}" != "13.*" ]]; then
+            composer require "pestphp/pest-plugin-laravel:^3.0" --no-interaction --no-update
+          fi
           composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,96 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - php: '8.3'
+            filament: '^3.0'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.4'
+            filament: '^3.0'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.5'
+            filament: '^3.0'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.3'
+            filament: '^4.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.4'
+            filament: '^4.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.5'
+            filament: '^4.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.3'
+            filament: '^5.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.4'
+            filament: '^5.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.5'
+            filament: '^5.0'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.3'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
+          - php: '8.4'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
+          - php: '8.5'
+            filament: '^5.0'
+            laravel: '13.*'
+            testbench: '11.*'
+
+    name: PHP ${{ matrix.php }} - Filament ${{ matrix.filament }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "filament/filament:${{ matrix.filament }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          if [[ "${{ matrix.laravel }}" != "13.*" ]]; then
+            composer require "pestphp/pest-plugin-laravel:^3.0" --no-interaction --no-update
+          fi
+          composer update --prefer-stable --prefer-dist --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/pest --ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - php: '8.3'
@@ -59,18 +59,6 @@ jobs:
             filament: '^5.0'
             laravel: '12.*'
             testbench: '10.*'
-          - php: '8.3'
-            filament: '^5.0'
-            laravel: '13.*'
-            testbench: '11.*'
-          - php: '8.4'
-            filament: '^5.0'
-            laravel: '13.*'
-            testbench: '11.*'
-          - php: '8.5'
-            filament: '^5.0'
-            laravel: '13.*'
-            testbench: '11.*'
 
     name: PHP ${{ matrix.php }} - Filament ${{ matrix.filament }} - Laravel ${{ matrix.laravel }}
 
@@ -87,9 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "filament/filament:${{ matrix.filament }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          if [[ "${{ matrix.laravel }}" != "13.*" ]]; then
-            composer require "pestphp/pest-plugin-laravel:^3.0" --no-interaction --no-update
-          fi
+          composer require "pestphp/pest-plugin-laravel:^3.0" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: Run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# filament-uppy
+
+## Versioning
+
+The major release version of this package must match `stechstudio/laravel-uppy-companion`. While we're in 0.x, the second digit is the major version (e.g. filament-uppy v0.6.x pairs with companion ^0.6). Once either package reaches 1.0+, the first digit must match.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Signature Tech Studio
+Copyright (c) 2024-2026 Signature Tech Studio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Filament Uppy Form Component
+
+![Tests](https://github.com/stechstudio/filament-uppy/actions/workflows/tests.yml/badge.svg)
+
 This package contains a [Filament](https://filamentphp.com/) form component called `UppyUploader` that integrates the
 [Uppy JS uploader](https://uppy.io) with our own [Laravel Uppy Companion](https://github.com/stechstudio/laravel-uppy-companion).
+
+## Compatibility
+
+| PHP | Laravel | Filament |
+|-----|---------|----------|
+| 8.3+ | 11, 12, 13 | 3, 4, 5 |
 
 ## Installation
 At this point, using this component still requires

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This package contains a [Filament](https://filamentphp.com/) form component call
 |-----|---------|----------|
 | 8.3+ | 11, 12, 13 | 3, 4, 5 |
 
+This package's major version tracks [laravel-uppy-companion](https://github.com/stechstudio/laravel-uppy-companion) (e.g. filament-uppy v0.6.x requires companion ^0.6). While in 0.x, the second digit is the major version.
+
 ## Installation
 At this point, using this component still requires
 [configuring the Laravel Uppy Companion](https://github.com/stechstudio/laravel-uppy-companion/blob/master/README.md#service-provider-configuration)

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
             "STS\\FilamentUppy\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "STS\\FilamentUppy\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "David Palmer",
@@ -14,15 +19,29 @@
         }
     ],
     "require": {
-        "filament/filament": "^3.0",
+        "php": "^8.3",
+        "filament/filament": "^3.0|^4.0|^5.0",
+        "spatie/laravel-package-tools": "^1.9",
         "stechstudio/laravel-uppy-companion": "^0.4"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.0|^3.0"
     },
     "repositories": [
         {
             "type": "git",
-            "url": "git@github.com:stechstudio/laravel-uppy-companion.git"
+            "url": "https://github.com/stechstudio/laravel-uppy-companion.git"
         }
     ],
+    "scripts": {
+        "test": "vendor/bin/pest"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^8.3",
         "filament/filament": "^3.0|^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.9",
-        "stechstudio/laravel-uppy-companion": "^0.4"
+        "stechstudio/laravel-uppy-companion": "^0.6"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use STS\FilamentUppy\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use STS\FilamentUppy\FilamentUppyPlugin;
+
+it('can be instantiated via make()', function () {
+    $plugin = FilamentUppyPlugin::make();
+    expect($plugin)->toBeInstanceOf(FilamentUppyPlugin::class);
+});
+
+it('has the correct plugin ID', function () {
+    $plugin = FilamentUppyPlugin::make();
+    expect($plugin->getId())->toBe('filament-uppy');
+});

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,6 @@
+<?php
+
+it('registers the views', function () {
+    $viewFactory = app('view');
+    expect($viewFactory->exists('filament-uppy::uppy-uploader'))->toBeTrue();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace STS\FilamentUppy\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use STS\FilamentUppy\FilamentUppyServiceProvider;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            FilamentUppyServiceProvider::class,
+        ];
+    }
+}

--- a/tests/UppyUploaderTest.php
+++ b/tests/UppyUploaderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use STS\FilamentUppy\UppyUploader;
+
+it('can be instantiated', function () {
+    $field = UppyUploader::make('files');
+    expect($field)->toBeInstanceOf(UppyUploader::class);
+});
+
+it('has the correct view', function () {
+    $field = UppyUploader::make('files');
+    expect($field->getView())->toBe('filament-uppy::uppy-uploader');
+});
+
+it('has default empty icon', function () {
+    $field = UppyUploader::make('files');
+    expect($field->getEmptyIcon())->toBe('heroicon-o-cloud-arrow-up');
+});
+
+it('has default empty message', function () {
+    $field = UppyUploader::make('files');
+    expect($field->getEmptyMessage())->toBe('Drop files here or click to upload.');
+});
+
+it('has empty default restrictions', function () {
+    $field = UppyUploader::make('files');
+    expect($field->getRestrictions())->toBe([]);
+});
+
+it('can set endpoints', function () {
+    $field = UppyUploader::make('files')
+        ->endpoints(upload: '/sign', success: '/success', delete: '/delete');
+
+    expect($field->getUploadEndpoint())->toBe('/sign')
+        ->and($field->getSuccessEndpoint())->toBe('/success')
+        ->and($field->getDeleteEndpoint())->toBe('/delete');
+});
+
+it('can set empty icon', function () {
+    $field = UppyUploader::make('files')
+        ->emptyIcon('heroicon-o-arrow-up-tray');
+
+    expect($field->getEmptyIcon())->toBe('heroicon-o-arrow-up-tray');
+});
+
+it('can set empty message', function () {
+    $field = UppyUploader::make('files')
+        ->emptyMessage('Upload your files');
+
+    expect($field->getEmptyMessage())->toBe('Upload your files');
+});
+
+it('can set restrictions', function () {
+    $restrictions = [
+        'maxFileSize' => 5242880,
+        'maxNumberOfFiles' => 10,
+        'allowedFileTypes' => ['image/*'],
+    ];
+
+    $field = UppyUploader::make('files')
+        ->restrictions($restrictions);
+
+    expect($field->getRestrictions())->toBe($restrictions);
+});


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with 12-combination matrix (PHP 8.3/8.4/8.5 × Filament 3/4/5 across Laravel 11/12/13)
- Widen `composer.json` to support `filament/filament ^3.0|^4.0|^5.0` and `php ^8.3`
- Bump `laravel-uppy-companion` to `^0.6` for Laravel 11-13 support
- Add Pest test suite with Orchestra Testbench: plugin, service provider, and UppyUploader component tests (12 tests, 14 assertions)
- Switch companion repo URL from SSH to HTTPS for CI compatibility
- Add compatibility table, CI badge, and versioning note to README
- Update LICENSE copyright to 2024-2026
- Add CLAUDE.md with versioning policy

## Test plan
- [x] All 12 tests pass locally against Filament 5 + PHP 8.4
- [x] GitHub Actions matrix runs across all 12 PHP/Filament/Laravel combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)